### PR TITLE
Add 'inspect' subcommand.

### DIFF
--- a/courseraprogramming/commands/__init__.py
+++ b/courseraprogramming/commands/__init__.py
@@ -1,5 +1,5 @@
 "Commands and their implementations for the courseraprogramming sdk."
 
-__all__ = ["cat", "config", "ls", "sanity", "upload", "version"]
+__all__ = ["cat", "config", "inspect", "ls", "sanity", "upload", "version"]
 
 from . import *  # noqa

--- a/courseraprogramming/commands/inspect.py
+++ b/courseraprogramming/commands/inspect.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+# Copyright 2015 Coursera
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Coursera's asynchronous grader command line SDK.
+
+You may install it from source, or via pip.
+"""
+
+from courseraprogramming.commands import common
+import logging
+import os
+
+
+def command_inspect(args):
+    'Implements the inspect subcommand'
+    command_line = [
+        'docker',
+        'run',
+        '-it',
+        '--entrypoint',
+        args.shell,
+        args.containerId,
+    ]
+    logging.debug("About to execute command: %s", ' '.join(command_line))
+    os.execvp('docker', command_line)
+
+
+def parser(subparsers):
+    "Build an argparse argument parser to parse the command line."
+    # create the parser for the inspect command
+    parser_inspect = subparsers.add_parser(
+        'inspect',
+        help='Starts a shell in the foreground inside your container to poke '
+             'around the container.',
+        parents=[common.container_parser()])
+    parser_inspect.set_defaults(func=command_inspect)
+    parser_inspect.add_argument(
+        '-s',
+        '--shell',
+        help='Shell to use.',
+        default='/bin/bash')
+    return parser_inspect

--- a/courseraprogramming/main.py
+++ b/courseraprogramming/main.py
@@ -64,6 +64,9 @@ def build_parser():
     # create the parser for the cat command
     commands.cat.parser(subparsers)
 
+    # create the parser for the inspect command
+    commands.inspect.parser(subparsers)
+
     # create the parser for the run command?
 
     # create the parser for the build command?

--- a/tests/commands/inspect_tests.py
+++ b/tests/commands/inspect_tests.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+# Copyright 2015 Coursera
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from courseraprogramming import main
+from courseraprogramming.commands import inspect
+from mock import patch
+
+
+def test_inspect_parsing():
+    parser = main.build_parser()
+    args = parser.parse_args('inspect demo/primes'.split())
+    assert args.func == inspect.command_inspect
+    assert args.containerId == 'demo/primes'
+
+
+@patch('courseraprogramming.commands.inspect.os')
+def test_ls_run(os):
+
+    # Set up args
+    args = argparse.Namespace()
+    args.containerId = 'testContainerId'
+    args.shell = '/bin/bash'
+
+    # Run the command
+    inspect.command_inspect(args)
+
+    # Verify correct command output
+    os.execvp.assert_called_with('docker', [
+        'docker',
+        'run',
+        '-it',
+        '--entrypoint',
+        '/bin/bash',
+        'testContainerId',
+    ])


### PR DESCRIPTION
Debugging interactively is good. This subcommand will launch an
interactive shell within a grader container to allow developers to
interactively poke at their containers to ensure everything is as
expected.
