### PR TITLE
Add 'grade local' subcommand for local grading

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,12 +4,16 @@ courseraprogramming
 .. image:: https://travis-ci.org/coursera/courseraprogramming.svg
     :target: https://travis-ci.org/coursera/courseraprogramming
 
-The grid sdk is a software development toolkit that helps to develop
+This command-line tool is a software development toolkit that helps to develop
 asynchronous graders for Coursera (typically programming assignments).
 
 To install this sdk, simply execute::
 
     sudo pip install courseraprogramming
+
+The tool includes its own usage information. Simply run::
+
+    courseraprogramming -h
 
 Developing
 ----------
@@ -33,9 +37,5 @@ Code Style
 
 Code should conform to pep8 style requirements. To check, simply run::
 
-    pep8 *.py
+    pep8 courseraprogramming tests
 
-Distributing
-^^^^^^^^^^^^
-
-TODO: package according to the latest best practices.

--- a/courseraprogramming/commands/__init__.py
+++ b/courseraprogramming/commands/__init__.py
@@ -1,5 +1,14 @@
 "Commands and their implementations for the courseraprogramming sdk."
 
-__all__ = ["cat", "config", "inspect", "ls", "sanity", "upload", "version"]
+__all__ = [
+    "cat",
+    "config",
+    "grade",
+    "inspect",
+    "ls",
+    "sanity",
+    "upload",
+    "version",
+]
 
 from . import *  # noqa

--- a/courseraprogramming/commands/grade.py
+++ b/courseraprogramming/commands/grade.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+
+# Copyright 2015 Coursera
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The grade subcommand executes the grader on a sample submission, simulating the
+way it would run within Coursera's production environment.
+"""
+
+import argparse
+from courseraprogramming.commands import common
+from courseraprogramming import utils
+import docker.utils
+import json
+import logging
+import sys
+
+
+EXTRA_DOC = """
+Beware: the Coursera Grid system uses a defense-in-depth strategy to protect
+against security vulnerabilities. Some of these layers are not reproducible
+outside of Coursera's environment.
+"""
+
+
+def run_container(docker, container, args):
+    "Runs the prepared container (and therefore grader), checking the output"
+    docker.start(container)
+    exit_code = docker.wait(container, timeout=args.timeout)
+    if exit_code != 0:
+        logging.warn("The grade command did not exit cleanly within the "
+                     "container. Exit code: %s", exit_code)
+
+    if logging.getLogger().isEnabledFor(logging.INFO):
+        stderr_output = docker.logs(container, stdout=False, stderr=True)
+        logging.info('Debug log:')
+        sys.stdout.write('-' * 80)
+        sys.stdout.write('\n')
+        sys.stdout.write(stderr_output)
+        sys.stdout.write('-' * 80)
+        sys.stdout.write('\n')
+
+    stdout_output = docker.logs(container, stdout=True, stderr=False)
+    error_in_grader_output = False
+    try:
+        lines = stdout_output.split('\n')
+        # Assert there is only one non-empty line in the output.
+        if len([line for line in lines if line != '']) != 1:
+            logging.error("The output did not have the right number of lines.")
+        parsed_output = json.loads(lines[0])
+    except ValueError:
+        logging.error("The output was not a valid JSON document.")
+        error_in_grader_output = True
+    else:
+        if "isCorrect" not in parsed_output:
+            logging.error("Field 'isCorrect' not present in parsed output.")
+            error_in_grader_output = True
+        elif not isinstance(parsed_output['isCorrect'], bool):
+            logging.error("Field 'isCorrect' is not a boolean value.")
+            error_in_grader_output = True
+
+        if "feedback" not in parsed_output:
+            logging.error("Field 'feedback' not present in parsed output.")
+            error_in_grader_output = True
+    finally:
+        if logging.getLogger().isEnabledFor(logging.WARNING):
+            sys.stdout.write('Grader output:\n')
+            sys.stdout.write('=' * 80)
+            sys.stdout.write('\n')
+            sys.stdout.write(stdout_output)
+            sys.stdout.write('=' * 80)
+            sys.stdout.write('\n')
+    if exit_code != 0 or error_in_grader_output:
+        sys.exit(1)
+
+
+def command_grade_local(args):
+    """
+    The 'local' sub-sub-command of the 'grade' sub-command simulates running a
+    grader on a sample submission from the local file system.
+    """
+    # TODO: Support arguments to pass to the graders.
+    d = utils.docker_client(args)
+    try:
+        volume_str = common.mk_submission_volume_str(args.dir)
+        logging.debug("Volume string: %s", volume_str)
+        container = d.create_container(
+            image=args.containerId,
+            network_disabled=True,
+            user='%s' % 1000,
+            host_config=docker.utils.create_host_config(binds=[
+                volume_str,
+            ]))
+    except:
+        logging.error(
+            "Could not set up the container to run the grade command in. Most "
+            "likely, this means that you specified an inappropriate container "
+            "id.")
+        raise
+    run_container(d, container, args)
+
+
+def parser(subparsers):
+    "Build an argparse argument parser to parse the command line."
+    module_doc_string = sys.modules[__name__].__doc__
+    # create the parser for the grade command
+    parser_grade = subparsers.add_parser(
+        'grade',
+        description=module_doc_string + EXTRA_DOC,
+        help=module_doc_string)
+
+    common_flags = argparse.ArgumentParser(add_help=False)
+    common_flags.add_argument(
+        '--timeout',
+        type=int,
+        default=300,
+        help='The time out the grader after TIMEOUT seconds')
+    grade_subparsers = parser_grade.add_subparsers()
+
+    # Local subsubcommand of the grade subcommand
+    parser_grade_local = grade_subparsers.add_parser(
+        'local',
+        help=command_grade_local.__doc__,
+        parents=[common_flags, common.container_parser()])
+
+    parser_grade_local.set_defaults(func=command_grade_local)
+    parser_grade_local.add_argument(
+        'dir',
+        help='Directory containing the submission.',
+        type=common.arg_fq_dir)
+    return parser_grade

--- a/courseraprogramming/main.py
+++ b/courseraprogramming/main.py
@@ -30,14 +30,15 @@ def build_parser():
     "Build an argparse argument parser to parse the command line."
 
     parser = argparse.ArgumentParser(
-        description="Coursera asynchronous grader command-line tool. This tool \
-        helps instructional teams as they develop sophisticated assignments. \
-        There are a number of subcommands, each with their own help \
-        documentation. Feel free to view them by executing `%(prog)s \
-        SUB_COMMAND -h`. For example: `%(prog)s ls -h`.",
-        epilog="Please report any bugs to 'app-platform@coursera.org'. If you \
-        would like to contribute to this tool's development, check us out at: \
-        https://github.com/coursera/gridSdk",
+        description="""Coursera asynchronous grader command-line tool. This tool
+        helps instructional teams as they develop sophisticated assignments.
+        There are a number of subcommands, each with their own help
+        documentation. Feel free to view them by executing `%(prog)s
+        SUB_COMMAND -h`. For example: `%(prog)s ls -h`.""",
+        epilog="""Please file bugs on github at:
+        https://github.com/coursera/courseraprogramming/issues. If you
+        would like to contribute to this tool's development, check us out at:
+        https://github.com/coursera/courseraprogramming""",
         parents=[utils.docker_client_arg_parser()])
     parser.add_argument('-c', '--config', help='the configuration file to use')
 
@@ -49,23 +50,26 @@ def build_parser():
     # from there.
     subparsers = parser.add_subparsers()
 
+    # create the parser for the cat command
+    commands.cat.parser(subparsers)
+
     # create the parser for the configure subcommand. (authentication / etc.)
     commands.config.parser(subparsers)
 
-    # create the parser for the version subcommand.
-    commands.version.parser(subparsers)
+    # create the parser for the grade subcommand.
+    commands.grade.parser(subparsers)
 
-    # create the parser for the sanity check command
-    commands.sanity.parser(subparsers)
+    # create the parser for the inspect command
+    commands.inspect.parser(subparsers)
 
     # create the parser for the ls command
     commands.ls.parser(subparsers)
 
-    # create the parser for the cat command
-    commands.cat.parser(subparsers)
+    # create the parser for the sanity check command
+    commands.sanity.parser(subparsers)
 
-    # create the parser for the inspect command
-    commands.inspect.parser(subparsers)
+    # create the parser for the version subcommand.
+    commands.version.parser(subparsers)
 
     # create the parser for the run command?
 

--- a/courseraprogramming/utils.py
+++ b/courseraprogramming/utils.py
@@ -64,9 +64,9 @@ def set_logging_level(args):
             sys.exit(2)
     elif "quiet" in args and args.quiet is not None:
         if args.quiet > 1:
-            level = logging.CRITICAL
-        elif args.quiet > 0:
             level = logging.ERROR
+        elif args.quiet > 0:
+            level = logging.WARNING
         else:
             logging.critical("quiet is an unexpected value. (%s) exiting.",
                              args.quiet)

--- a/tests/commands/grade_tests.py
+++ b/tests/commands/grade_tests.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python
+
+# Copyright 2015 Coursera
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import docker
+from courseraprogramming import main
+from courseraprogramming.commands import grade
+from mock import MagicMock
+from mock import patch
+from testfixtures import LogCapture
+
+
+def test_grade_local_parsing():
+    # TODO: mock out `os.path.isdir` to make this test more portable.
+    parser = main.build_parser()
+    args = parser.parse_args('grade local myContainerId /tmp'.split())
+    assert args.func == grade.command_grade_local
+    assert args.containerId == 'myContainerId'
+    assert args.dir == '/tmp'
+
+
+@patch('courseraprogramming.commands.grade.sys')
+def test_check_output_bad_isCorrect(sys):
+    with LogCapture() as logs:
+        docker_mock = MagicMock()
+        container = {
+            "Id": "myContainerId"
+        }
+        args = argparse.Namespace()
+        args.timeout = 300
+
+        docker_mock.wait.return_value = 0
+        docker_mock.logs.side_effect = [
+            '',
+            '{"isCorrect":"true-string-is-not-true","feedback":"You win!"}'
+        ]
+        # Run the function under test
+        grade.run_container(docker_mock, container, args)
+    logs.check(
+        ('root', 'INFO', 'Debug log:'),
+        ('root', 'ERROR', "Field 'isCorrect' is not a boolean value.")
+    )
+    sys.exit.assert_called_with(1)
+
+
+@patch('courseraprogramming.commands.grade.sys')
+def test_check_output_no_feedback(sys):
+    with LogCapture() as logs:
+        docker_mock = MagicMock()
+        container = {
+            "Id": "myContainerId"
+        }
+        args = argparse.Namespace()
+        args.timeout = 300
+
+        docker_mock.wait.return_value = 0
+        docker_mock.logs.side_effect = [
+            '',
+            '{"isCorrect":false, "not-feedback": "garbage"}'
+        ]
+        # Run the function under test
+        grade.run_container(docker_mock, container, args)
+    logs.check(
+        ('root', 'INFO', 'Debug log:'),
+        ('root', 'ERROR', "Field 'feedback' not present in parsed output.")
+    )
+    sys.exit.assert_called_with(1)
+
+
+@patch('courseraprogramming.commands.grade.sys')
+def test_check_output_malformed_output(sys):
+    with LogCapture() as logs:
+        docker_mock = MagicMock()
+        container = {
+            "Id": "myContainerId"
+        }
+        args = argparse.Namespace()
+        args.timeout = 300
+
+        docker_mock.wait.return_value = 0
+        docker_mock.logs.side_effect = [
+            '',
+            '{"isCorrect":false, "not-feedback": "garbageeeeeeee'
+        ]
+        # Run the function under test
+        grade.run_container(docker_mock, container, args)
+    logs.check(
+        ('root', 'INFO', 'Debug log:'),
+        ('root', 'ERROR', "The output was not a valid JSON document.")
+    )
+    sys.exit.assert_called_with(1)
+
+
+@patch('courseraprogramming.commands.grade.sys')
+def test_check_output_bad_return_code(sys):
+    with LogCapture():
+        docker_mock = MagicMock()
+        container = {
+            "Id": "myContainerId"
+        }
+        args = argparse.Namespace()
+        args.timeout = 300
+
+        docker_mock.wait.return_value = 1
+        docker_mock.logs.side_effect = [
+            'debug output',
+            '{"isCorrect":true,"feedback":"You win!"}'
+        ]
+        # Run the function under test
+        grade.run_container(docker_mock, container, args)
+    sys.exit.assert_called_with(1)
+
+
+@patch('courseraprogramming.commands.grade.sys')
+def test_check_output_good_output(sys):
+    with LogCapture() as logs:
+        docker_mock = MagicMock()
+        container = {
+            "Id": "myContainerId"
+        }
+        args = argparse.Namespace()
+        args.timeout = 300
+
+        docker_mock.wait.return_value = 0
+        docker_mock.logs.side_effect = [
+            '',
+            '{"isCorrect":false, "feedback": "Helpful comment!"}'
+        ]
+        # Run the function under test
+        grade.run_container(docker_mock, container, args)
+    logs.check(
+        ('root', 'INFO', 'Debug log:'),
+    )
+    assert not sys.exit.called, "sys.exit should not be called!"
+
+
+@patch('courseraprogramming.commands.grade.common')
+@patch('courseraprogramming.commands.grade.utils')
+@patch('courseraprogramming.commands.grade.run_container')
+def test_command_local_grade_simple(run_container, utils, common):
+    args = argparse.Namespace()
+    args.dir = '/tmp'
+    args.containerId = 'myContainerId'
+    common.mk_submission_volume_str.return_value = 'foo'
+    docker_mock = MagicMock()
+    docker_mock.create_container.return_value = {
+        "Id": "myContainerInstanceId",
+    }
+    utils.docker_client.return_value = docker_mock
+
+    grade.command_grade_local(args)
+
+    docker_mock.create_container.assert_called_with(
+        image='myContainerId',
+        network_disabled=True,
+        user='1000',
+        host_config=docker.utils.create_host_config(binds=[
+            'foo',
+        ])
+    )
+    run_container.assert_called_with(
+        docker_mock,
+        docker_mock.create_container.return_value,
+        args)

--- a/tests/commands/sanity_test.py
+++ b/tests/commands/sanity_test.py
@@ -59,8 +59,6 @@ def test_command_sanity():
     for testcase in testCases:
         testFn = command_sanity_impl
         testFn.description = 'test_command_sanity: %s' % testcase[0]
-        print ":LKJSDF:LSKJDF:LSJKDF:LKSJ:DFLKJSD:LFKJL:JE"
-        print "Test name: %s, input: %s, output: %s" % testcase
         yield testFn, testcase[1], testcase[2]
 
 


### PR DESCRIPTION
Easily building the containers is useless, unless you can also run
them locally. The 'grade' subcommand will allow for local execution of
the grader container. The 'local' sub-sub-command instructs the grader
to be run on a submission found on the local file system. In the
future, there will be another sub-sub-command to allow for easy
execution against a true submission downloaded from Coursera.

This commit also cleans up a few tinkercruft things.
