### PR TITLE
Configure network during inspect subcommand

### DIFF
--- a/courseraprogramming/commands/inspect.py
+++ b/courseraprogramming/commands/inspect.py
@@ -37,6 +37,9 @@ def command_inspect(args):
     if 'submission' in args and args.submission is not None:
         command_line.append('-v')
         command_line.append(common.mk_submission_volume_str(args.submission))
+    if not args.allow_network:
+        command_line.append('--net')
+        command_line.append('none')
     command_line.append(args.containerId)
     logging.debug("About to execute command: %s", ' '.join(command_line))
     os.execvp('docker', command_line)
@@ -61,4 +64,8 @@ def parser(subparsers):
         '--submission',
         help='Submission directory to mount into the container.',
         type=common.arg_fq_dir)
+    parser_inspect.add_argument(
+        '--allow-network',
+        action='store_true',
+        help='Enable network access within the container. (Default off.)')
     return parser_inspect

--- a/tests/commands/inspect_tests.py
+++ b/tests/commands/inspect_tests.py
@@ -34,6 +34,32 @@ def test_ls_run(os):
     args = argparse.Namespace()
     args.containerId = 'testContainerId'
     args.shell = '/bin/bash'
+    args.allow_network = False
+
+    # Run the command
+    inspect.command_inspect(args)
+
+    # Verify correct command output
+    os.execvp.assert_called_with('docker', [
+        'docker',
+        'run',
+        '-it',
+        '--entrypoint',
+        '/bin/bash',
+        '--net',
+        'none',
+        'testContainerId',
+    ])
+
+
+@patch('courseraprogramming.commands.inspect.os')
+def test_ls_run_with_network(os):
+
+    # Set up args
+    args = argparse.Namespace()
+    args.containerId = 'testContainerId'
+    args.shell = '/bin/bash'
+    args.allow_network = True
 
     # Run the command
     inspect.command_inspect(args)


### PR DESCRIPTION
Configure the network in a similar fashion to how the network will
be in the production environment. This implies a loopback device is
available, but no external connectivity.
