### PR TITLE
Add memory limits on containers.

### DIFF
--- a/courseraprogramming/commands/grade.py
+++ b/courseraprogramming/commands/grade.py
@@ -102,7 +102,9 @@ def command_grade_local(args):
             host_config=docker.utils.create_host_config(
                 binds=[volume_str, ],
                 network_mode='none',
-            ))
+            ),
+            mem_limit='1g',
+        )
     except:
         logging.error(
             "Could not set up the container to run the grade command in. Most "

--- a/courseraprogramming/commands/inspect.py
+++ b/courseraprogramming/commands/inspect.py
@@ -40,6 +40,9 @@ def command_inspect(args):
     if not args.allow_network:
         command_line.append('--net')
         command_line.append('none')
+    if not args.unlimited_memory:
+        command_line.append('-m')
+        command_line.append('1g')
     command_line.append(args.containerId)
     logging.debug("About to execute command: %s", ' '.join(command_line))
     os.execvp('docker', command_line)
@@ -68,4 +71,8 @@ def parser(subparsers):
         '--allow-network',
         action='store_true',
         help='Enable network access within the container. (Default off.)')
+    parser_inspect.add_argument(
+        '--unlimited-memory',
+        action='store_true',
+        help='Remove memory limits. (Default: limited memory.)')
     return parser_inspect

--- a/tests/commands/grade_tests.py
+++ b/tests/commands/grade_tests.py
@@ -169,7 +169,8 @@ def test_command_local_grade_simple(run_container, utils, common):
         host_config=docker.utils.create_host_config(
             binds=['foo', ],
             network_mode='none',
-        )
+        ),
+        mem_limit='1g',
     )
     run_container.assert_called_with(
         docker_mock,

--- a/tests/commands/inspect_tests.py
+++ b/tests/commands/inspect_tests.py
@@ -35,6 +35,7 @@ def test_ls_run(os):
     args.containerId = 'testContainerId'
     args.shell = '/bin/bash'
     args.allow_network = False
+    args.unlimited_memory = False
 
     # Run the command
     inspect.command_inspect(args)
@@ -48,18 +49,21 @@ def test_ls_run(os):
         '/bin/bash',
         '--net',
         'none',
+        '-m',
+        '1g',
         'testContainerId',
     ])
 
 
 @patch('courseraprogramming.commands.inspect.os')
-def test_ls_run_with_network(os):
+def test_ls_run_without_limits(os):
 
     # Set up args
     args = argparse.Namespace()
     args.containerId = 'testContainerId'
     args.shell = '/bin/bash'
     args.allow_network = True
+    args.unlimited_memory = True
 
     # Run the command
     inspect.command_inspect(args)


### PR DESCRIPTION
Enable memory limits for containers started by courseraprogramming in
order to more accurately simulate the production environment. Note:
we ignore memory settings on containers started by the `cat` and `ls`
subcommands, as they should not have any memory or network usage in
the first place.

Further, we allow users to remove memory (and network) restrictions
on containers started from the `inspect` subcommand to allow users to
poke at things in an unrestricted manner. That said, by default we
enable all limits to mimic the real environment as much as possible.
