### PR TITLE
Additional Dockerfile checks for the santy command

### DIFF
--- a/courseraprogramming/commands/sanity.py
+++ b/courseraprogramming/commands/sanity.py
@@ -82,6 +82,12 @@ def command_sanity(args):
                             'or binary as the ENTRYPOINT, and not bash', {
                                 'lineno': cmd['startline'],
                             })
+                if cmd['instruction'].lower() == 'expose':
+                    logging.warn(
+                        'Line %(lineno)s: EXPOSE commands do not work for '
+                        'graders', {
+                            'lineno': cmd['startline'],
+                        })
             if not seen_entrypoint:
                 logging.warn('Your Dockerfile must define an ENTRYPOINT.')
     else:

--- a/tests/commands/sanity_test.py
+++ b/tests/commands/sanity_test.py
@@ -55,6 +55,17 @@ def test_command_sanity():
             "ENTRYPOINT /bin/bash"], (
             ('root', 'WARNING', 'Line 2: Please mark your grading script or '
                 'binary as the ENTRYPOINT, and not bash'),)),
+        ("expose_command", [
+            "FROM debian\n",
+            "\n",
+            "ENTRYPOINT /grader.sh\n",
+            "EXPOSE 80"], (
+            ('root', 'WARNING', 'Line 3: EXPOSE commands do not work for '
+                'graders'),)),
+        ("good_script", [
+            "FROM debian\n",
+            "\n",
+            "ENTRYPOINT /grader.sh\n"], ()),
     ]
     for testcase in testCases:
         testFn = command_sanity_impl


### PR DESCRIPTION
Dockerfiles for graders should not have any `EXPOSE` directives, as
they are almost certainly inappropriate. Networking is disabled within
the Coursera production environment, so any attempt to map ports on
the host into the container is not supported.
