### PR TITLE
Warn about use of ENV in Dockerfiles

### DIFF
--- a/courseraprogramming/commands/sanity.py
+++ b/courseraprogramming/commands/sanity.py
@@ -88,6 +88,14 @@ def command_sanity(args):
                         'graders', {
                             'lineno': cmd['startline'],
                         })
+                if cmd['instruction'].lower() == 'env':
+                    logging.warn(
+                        'Line %(lineno)s: ENV-based environment variables are '
+                        'stripped in the production environment for security '
+                        'reasons. Please set any environment variables you '
+                        'need in your grading script.', {
+                            'lineno': cmd['startline'],
+                        })
             if not seen_entrypoint:
                 logging.warn('Your Dockerfile must define an ENTRYPOINT.')
     else:

--- a/tests/commands/sanity_test.py
+++ b/tests/commands/sanity_test.py
@@ -62,6 +62,15 @@ def test_command_sanity():
             "EXPOSE 80"], (
             ('root', 'WARNING', 'Line 3: EXPOSE commands do not work for '
                 'graders'),)),
+        ("env_commands", [
+            "FROM debian\n",
+            "\n",
+            "ENV FOO=bar\n",
+            "ENTRYPOINT /grader.sh\n"], (
+            ('root', 'WARNING', 'Line 2: ENV-based environment variables '
+                'are stripped in the production environment for security '
+                'reasons. Please set any environment variables you need '
+                'in your grading script.'),)),
         ("good_script", [
             "FROM debian\n",
             "\n",


### PR DESCRIPTION
For security reasons, we sanitize the environment when executing
graders. Therefore, almost all uses of `ENV` commands in Dockerfiles
is likely to not behave as expected. This commit adds a check in the
`sanity` subcommand to warn instructional teams when they use the
`ENV` command in `Dockerfile`s.
