### PR TITLE
Run a user id 1000 when inspecting interactively

### DIFF
--- a/courseraprogramming/commands/inspect.py
+++ b/courseraprogramming/commands/inspect.py
@@ -43,6 +43,10 @@ def command_inspect(args):
     if not args.unlimited_memory:
         command_line.append('-m')
         command_line.append('1g')
+    if not args.super_user:
+        # Note: docker run CLI doesn't support setting the group. :-(
+        command_line.append('-u')
+        command_line.append('1000')
     command_line.append(args.containerId)
     logging.debug("About to execute command: %s", ' '.join(command_line))
     os.execvp('docker', command_line)
@@ -75,4 +79,8 @@ def parser(subparsers):
         '--unlimited-memory',
         action='store_true',
         help='Remove memory limits. (Default: limited memory.)')
+    parser_inspect.add_argument(
+        '--super-user',
+        action='store_true',
+        help='Inspect as super-user. (Default: userid 1000.)')
     return parser_inspect

--- a/tests/commands/inspect_tests.py
+++ b/tests/commands/inspect_tests.py
@@ -36,6 +36,7 @@ def test_ls_run(os):
     args.shell = '/bin/bash'
     args.allow_network = False
     args.unlimited_memory = False
+    args.super_user = False
 
     # Run the command
     inspect.command_inspect(args)
@@ -51,6 +52,8 @@ def test_ls_run(os):
         'none',
         '-m',
         '1g',
+        '-u',
+        '1000',
         'testContainerId',
     ])
 
@@ -64,6 +67,7 @@ def test_ls_run_without_limits(os):
     args.shell = '/bin/bash'
     args.allow_network = True
     args.unlimited_memory = True
+    args.super_user = True
 
     # Run the command
     inspect.command_inspect(args)


### PR DESCRIPTION
In order to accurately simulate the production environment when
inspecting interactively locally, run as user id 1000. Important note:
the docker CLI doesn't support setting the group id on the command
line.
