### PR TITLE
Set `mem_limit` and `memswap_limit` in hostconfig

### DIFF
--- a/courseraprogramming/commands/grade.py
+++ b/courseraprogramming/commands/grade.py
@@ -102,8 +102,9 @@ def command_grade_local(args):
             host_config=docker.utils.create_host_config(
                 binds=[volume_str, ],
                 network_mode='none',
+                mem_limit='1g',
+                memswap_limit='1g',
             ),
-            mem_limit='1g',
         )
     except:
         logging.error(

--- a/tests/commands/grade_tests.py
+++ b/tests/commands/grade_tests.py
@@ -169,8 +169,9 @@ def test_command_local_grade_simple(run_container, utils, common):
         host_config=docker.utils.create_host_config(
             binds=['foo', ],
             network_mode='none',
+            mem_limit='1g',
+            memswap_limit='1g',
         ),
-        mem_limit='1g',
     )
     run_container.assert_called_with(
         docker_mock,


### PR DESCRIPTION
Since docker API version 1.19, `mem_limit` and `memswap_limit` live
not in the top-level config for a container, but rather in the
`host_config` sub-section of the container configuration. This change
brings the `courseraprogramming grade` subcommand with the latest
docker API versions.
