### PR TITLE
Support new output formats.

### DIFF
--- a/courseraprogramming/commands/grade.py
+++ b/courseraprogramming/commands/grade.py
@@ -64,13 +64,27 @@ def run_container(docker, container, args):
         logging.error("The output was not a valid JSON document.")
         error_in_grader_output = True
     else:
-        if "isCorrect" not in parsed_output:
-            logging.error("Field 'isCorrect' not present in parsed output.")
+        if "fractionalScore" in parsed_output:
+            if isinstance(parsed_output['fractionalScore'], bool):
+                logging.error("Field 'fractionalScore' must be a decimal.")
+                error_in_grader_output = True
+            elif not (isinstance(parsed_output['fractionalScore'], float) or
+                      isinstance(parsed_output['fractionalScore'], int)):
+                logging.error("Field 'fractionalScore' must be a decimal.")
+                error_in_grader_output = True
+            elif parsed_output['fractionalScore'] > 1:
+                logging.error("Field 'fractionalScore' must be <= 1.")
+                error_in_grader_output = True
+            elif parsed_output['fractionalScore'] < 0:
+                logging.error("Field 'fractionalScore' must be >= 0.")
+                error_in_grader_output = True
+        elif "isCorrect" in parsed_output:
+            if not isinstance(parsed_output['isCorrect'], bool):
+                logging.error("Field 'isCorrect' is not a boolean value.")
+                error_in_grader_output = True
+        else:
+            logging.error("Required field 'fractionalScore' is missing.")
             error_in_grader_output = True
-        elif not isinstance(parsed_output['isCorrect'], bool):
-            logging.error("Field 'isCorrect' is not a boolean value.")
-            error_in_grader_output = True
-
         if "feedback" not in parsed_output:
             logging.error("Field 'feedback' not present in parsed output.")
             error_in_grader_output = True

--- a/tests/commands/grade_tests.py
+++ b/tests/commands/grade_tests.py
@@ -81,6 +81,126 @@ def test_check_output_no_feedback(sys):
 
 
 @patch('courseraprogramming.commands.grade.sys')
+def test_check_output_fractional_score_boolean(sys):
+    with LogCapture() as logs:
+        docker_mock = MagicMock()
+        container = {
+            "Id": "myContainerId"
+        }
+        args = argparse.Namespace()
+        args.timeout = 300
+
+        docker_mock.wait.return_value = 0
+        docker_mock.logs.side_effect = [
+            '',
+            '{"fractionalScore": false, "feedback": "wheeeee"}'
+        ]
+        # Run the function under test
+        grade.run_container(docker_mock, container, args)
+    logs.check(
+        ('root', 'INFO', 'Debug log:'),
+        ('root', 'ERROR', "Field 'fractionalScore' must be a decimal.")
+    )
+    sys.exit.assert_called_with(1)
+
+
+@patch('courseraprogramming.commands.grade.sys')
+def test_check_output_fractional_score_string(sys):
+    with LogCapture() as logs:
+        docker_mock = MagicMock()
+        container = {
+            "Id": "myContainerId"
+        }
+        args = argparse.Namespace()
+        args.timeout = 300
+
+        docker_mock.wait.return_value = 0
+        docker_mock.logs.side_effect = [
+            '',
+            '{"fractionalScore": "0.3", "feedback": "wheeeee"}'
+        ]
+        # Run the function under test
+        grade.run_container(docker_mock, container, args)
+    logs.check(
+        ('root', 'INFO', 'Debug log:'),
+        ('root', 'ERROR', "Field 'fractionalScore' must be a decimal.")
+    )
+    sys.exit.assert_called_with(1)
+
+
+@patch('courseraprogramming.commands.grade.sys')
+def test_check_output_fractional_score_too_high(sys):
+    with LogCapture() as logs:
+        docker_mock = MagicMock()
+        container = {
+            "Id": "myContainerId"
+        }
+        args = argparse.Namespace()
+        args.timeout = 300
+
+        docker_mock.wait.return_value = 0
+        docker_mock.logs.side_effect = [
+            '',
+            '{"fractionalScore":1.1, "feedback": "wheeeee"}'
+        ]
+        # Run the function under test
+        grade.run_container(docker_mock, container, args)
+    logs.check(
+        ('root', 'INFO', 'Debug log:'),
+        ('root', 'ERROR', "Field 'fractionalScore' must be <= 1.")
+    )
+    sys.exit.assert_called_with(1)
+
+
+@patch('courseraprogramming.commands.grade.sys')
+def test_check_output_fractional_score_too_low(sys):
+    with LogCapture() as logs:
+        docker_mock = MagicMock()
+        container = {
+            "Id": "myContainerId"
+        }
+        args = argparse.Namespace()
+        args.timeout = 300
+
+        docker_mock.wait.return_value = 0
+        docker_mock.logs.side_effect = [
+            '',
+            '{"fractionalScore":-1.1, "feedback": "wheeeee"}'
+        ]
+        # Run the function under test
+        grade.run_container(docker_mock, container, args)
+    logs.check(
+        ('root', 'INFO', 'Debug log:'),
+        ('root', 'ERROR', "Field 'fractionalScore' must be >= 0.")
+    )
+    sys.exit.assert_called_with(1)
+
+
+@patch('courseraprogramming.commands.grade.sys')
+def test_check_output_missing_grade(sys):
+    with LogCapture() as logs:
+        docker_mock = MagicMock()
+        container = {
+            "Id": "myContainerId"
+        }
+        args = argparse.Namespace()
+        args.timeout = 300
+
+        docker_mock.wait.return_value = 0
+        docker_mock.logs.side_effect = [
+            '',
+            '{"feedback": "wheeeee"}'
+        ]
+        # Run the function under test
+        grade.run_container(docker_mock, container, args)
+    logs.check(
+        ('root', 'INFO', 'Debug log:'),
+        ('root', 'ERROR', "Required field 'fractionalScore' is missing.")
+    )
+    sys.exit.assert_called_with(1)
+
+
+@patch('courseraprogramming.commands.grade.sys')
 def test_check_output_malformed_output(sys):
     with LogCapture() as logs:
         docker_mock = MagicMock()
@@ -125,7 +245,7 @@ def test_check_output_bad_return_code(sys):
 
 
 @patch('courseraprogramming.commands.grade.sys')
-def test_check_output_good_output(sys):
+def test_check_output_good_output_is_correct(sys):
     with LogCapture() as logs:
         docker_mock = MagicMock()
         container = {
@@ -138,6 +258,121 @@ def test_check_output_good_output(sys):
         docker_mock.logs.side_effect = [
             '',
             '{"isCorrect":false, "feedback": "Helpful comment!"}'
+        ]
+        # Run the function under test
+        grade.run_container(docker_mock, container, args)
+    logs.check(
+        ('root', 'INFO', 'Debug log:'),
+    )
+    assert not sys.exit.called, "sys.exit should not be called!"
+
+
+@patch('courseraprogramming.commands.grade.sys')
+def test_check_output_good_output_fractional_score(sys):
+    with LogCapture() as logs:
+        docker_mock = MagicMock()
+        container = {
+            "Id": "myContainerId"
+        }
+        args = argparse.Namespace()
+        args.timeout = 300
+
+        docker_mock.wait.return_value = 0
+        docker_mock.logs.side_effect = [
+            '',
+            '{"fractionalScore":0.2, "feedback": "Helpful comment!"}'
+        ]
+        # Run the function under test
+        grade.run_container(docker_mock, container, args)
+    logs.check(
+        ('root', 'INFO', 'Debug log:'),
+    )
+    assert not sys.exit.called, "sys.exit should not be called!"
+
+
+@patch('courseraprogramming.commands.grade.sys')
+def test_check_output_good_output_fractional_score_one(sys):
+    with LogCapture() as logs:
+        docker_mock = MagicMock()
+        container = {
+            "Id": "myContainerId"
+        }
+        args = argparse.Namespace()
+        args.timeout = 300
+
+        docker_mock.wait.return_value = 0
+        docker_mock.logs.side_effect = [
+            '',
+            '{"fractionalScore":1, "feedback": "Helpful comment!"}'
+        ]
+        # Run the function under test
+        grade.run_container(docker_mock, container, args)
+    logs.check(
+        ('root', 'INFO', 'Debug log:'),
+    )
+    assert not sys.exit.called, "sys.exit should not be called!"
+
+
+@patch('courseraprogramming.commands.grade.sys')
+def test_check_output_good_output_fractional_score_one_point_oh(sys):
+    with LogCapture() as logs:
+        docker_mock = MagicMock()
+        container = {
+            "Id": "myContainerId"
+        }
+        args = argparse.Namespace()
+        args.timeout = 300
+
+        docker_mock.wait.return_value = 0
+        docker_mock.logs.side_effect = [
+            '',
+            '{"fractionalScore":1.0, "feedback": "Helpful comment!"}'
+        ]
+        # Run the function under test
+        grade.run_container(docker_mock, container, args)
+    logs.check(
+        ('root', 'INFO', 'Debug log:'),
+    )
+    assert not sys.exit.called, "sys.exit should not be called!"
+
+
+@patch('courseraprogramming.commands.grade.sys')
+def test_check_output_good_output_fractional_score_zero(sys):
+    with LogCapture() as logs:
+        docker_mock = MagicMock()
+        container = {
+            "Id": "myContainerId"
+        }
+        args = argparse.Namespace()
+        args.timeout = 300
+
+        docker_mock.wait.return_value = 0
+        docker_mock.logs.side_effect = [
+            '',
+            '{"fractionalScore":0, "feedback": "Helpful comment!"}'
+        ]
+        # Run the function under test
+        grade.run_container(docker_mock, container, args)
+    logs.check(
+        ('root', 'INFO', 'Debug log:'),
+    )
+    assert not sys.exit.called, "sys.exit should not be called!"
+
+
+@patch('courseraprogramming.commands.grade.sys')
+def test_check_output_good_output_fractional_score_zero_point_oh(sys):
+    with LogCapture() as logs:
+        docker_mock = MagicMock()
+        container = {
+            "Id": "myContainerId"
+        }
+        args = argparse.Namespace()
+        args.timeout = 300
+
+        docker_mock.wait.return_value = 0
+        docker_mock.logs.side_effect = [
+            '',
+            '{"fractionalScore":0.0, "feedback": "Helpful comment!"}'
         ]
         # Run the function under test
         grade.run_container(docker_mock, container, args)


### PR DESCRIPTION
For pedagogical reasons, we are expanding the range of valid outputs
from graders to expand beyond a single boolean for the grade to
include a floating point number between 0 and 1. This commit expands
the checking for grade output to support the new 'fractionalScore'
value in the JSON output.
