### PR TITLE
Remove create_host_config warning

### DIFF
--- a/courseraprogramming/commands/grade.py
+++ b/courseraprogramming/commands/grade.py
@@ -113,7 +113,7 @@ def command_grade_local(args):
         container = d.create_container(
             image=args.containerId,
             user='%s' % 1000,
-            host_config=docker.utils.create_host_config(
+            host_config=d.create_host_config(
                 binds=[volume_str, ],
                 network_mode='none',
                 mem_limit='1g',

--- a/tests/commands/grade_tests.py
+++ b/tests/commands/grade_tests.py
@@ -395,18 +395,21 @@ def test_command_local_grade_simple(run_container, utils, common):
         "Id": "myContainerInstanceId",
     }
     utils.docker_client.return_value = docker_mock
+    h_config = {'foo': 'bar'} # just some unique value
+    docker_mock.create_host_config.return_value = h_config
 
     grade.command_grade_local(args)
 
     docker_mock.create_container.assert_called_with(
         image='myContainerId',
         user='1000',
-        host_config=docker.utils.create_host_config(
-            binds=['foo', ],
-            network_mode='none',
-            mem_limit='1g',
-            memswap_limit='1g',
-        ),
+        host_config=h_config,
+    )
+    docker_mock.create_host_config.assert_called_with(
+        binds=['foo', ],
+        network_mode='none',
+        mem_limit='1g',
+        memswap_limit='1g',
     )
     run_container.assert_called_with(
         docker_mock,

--- a/tests/commands/grade_tests.py
+++ b/tests/commands/grade_tests.py
@@ -395,7 +395,7 @@ def test_command_local_grade_simple(run_container, utils, common):
         "Id": "myContainerInstanceId",
     }
     utils.docker_client.return_value = docker_mock
-    h_config = {'foo': 'bar'} # just some unique value
+    h_config = {'foo': 'bar'}  # just some unique value
     docker_mock.create_host_config.return_value = h_config
 
     grade.command_grade_local(args)


### PR DESCRIPTION
Anytime 
    courseragrader grade local
was run, the following error was generated:
        WARNING:py.warnings:/Library/Python/2.7/site-packages/docker/utils/utils.py:486: UserWarning: docker.utils.create_host_config() is deprecated. Please use Client.create_host_config() instead

This patch removes that warning by using Client.create_host_config() instead of docker.utils.create_host_config()
