### PR TITLE
Increase timeout before checking upload status.

### DIFF
--- a/courseraprogramming/commands/upload.py
+++ b/courseraprogramming/commands/upload.py
@@ -204,7 +204,7 @@ def command_upload(args):
     p = multiprocessing.Process(target=upload, args=(args, upload_url, image))
     p.daemon = True  # Auto-kill when the main process exits.
     p.start()
-    time.sleep(10)  # Yield control to the child process to kick off upload.
+    time.sleep(20)  # Yield control to the child process to kick off upload.
 
     upload_information = None
 


### PR DESCRIPTION
Timeout of 10 seconds wasn't always enough: when checking upload status,
the upload ID wasn't known yet.
