### PR TITLE
[sanity] Add additional docker version check.

### DIFF
--- a/courseraprogramming/commands/sanity.py
+++ b/courseraprogramming/commands/sanity.py
@@ -40,7 +40,10 @@ def command_sanity(args):
         docker_version = conn.version()
         logging.info("Docker version: %s", docker_version["Version"])
         if semver.match(docker_version["Version"], '>1.5.0'):
-            logging.info("Docker version ok.")
+            if semver.match(docker_version["Version"], '<=1.9.1'):
+                logging.info("Docker version ok.")
+            else:
+                logging.error("Docker version must be <=1.9.1")
         else:
             logging.error("Docker version must be >1.5.0.")
 


### PR DESCRIPTION
Currently, Coursera's security features are incompatible with docker 1.10+. This
commit adds an additional environment check to ensure that the docker version is
acceptable on the upper end.
