### PR TITLE
Fix `grade local` docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,7 @@ handle problematic submissions.
 
 Examples:
  - ``courseraprogramming grade local $MY_CONTAINER_IMAGE
-   /path/to/sample/submission``
+   /path/to/sample/submission/``
    invokes the grader passing in the sample submission into the grader.
  - ``courseraprogramming grade local --help`` displays the full list of
    flags and options available.


### PR DESCRIPTION
If the argument is the path to the submission (a folder), it should end with `/`, otherwise it leads to confusion, making the user think that's the submission file.
