### PR TITLE
Re-throw SystemExit exceptions for correct exit

### DIFF
--- a/courseraprogramming/main.py
+++ b/courseraprogramming/main.py
@@ -92,7 +92,7 @@ def main():
     try:
         return args.func(args)
     except SystemExit:
-        pass
+        raise
     except:
         logging.exception('Problem when running command. Sorry!')
         sys.exit(1)


### PR DESCRIPTION
In an attempt to avoid re-logging the `SystemExit` exceptions, we special case them out. However, we should re-`raise` them in order to maintain the proper exit code returned to the calling program.
