### PR TITLE
Rename containerId to imageId

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,9 +79,9 @@ Examples:
    the container running as a deprivileged user, with memory constraints and the
    network configured similar to the production environment.
  - ``courseraprogramming inspect --super-user --unlimited-memory --allow-network
-   $MY_CONTAINER_ID`` launches a shell running as a root user with the
+   $MY_CONTAINER_IMAGE`` launches a shell running as a root user with the
    production-simulating constraints removed.
- - ``courseraprogramming inspect -d /path/to/sample/submission $MY_CONTAINER_ID``
+ - ``courseraprogramming inspect -d /path/to/sample/submission $MY_CONTAINER_IMAGE``
    launches a container mapping the sample submission on the host into the
    grading container. If you interactively invoke the configured grading script
    and interactively debug your grader.

--- a/courseraprogramming/commands/cat.py
+++ b/courseraprogramming/commands/cat.py
@@ -31,7 +31,7 @@ def command_cat(args):
     d = utils.docker_client(args)
     try:
         container = d.create_container(
-            image=args.containerId,
+            image=args.imageId,
             entrypoint="/bin/cat",
             command=args.file)
     except:

--- a/courseraprogramming/commands/common.py
+++ b/courseraprogramming/commands/common.py
@@ -31,8 +31,8 @@ def container_parser():
     # all these options here.
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument(
-        'containerId',
-        help='The container id to operate on.')
+        'imageId',
+        help='The container image id or container tag to operate on.')
 
     return parser
 

--- a/courseraprogramming/commands/grade.py
+++ b/courseraprogramming/commands/grade.py
@@ -132,7 +132,7 @@ def command_grade_local(args):
         if 'args' in args and len(args.args) > 0:
             # Handle additional command-line arguments which will
             # be passed to the grader.
-            inspect = d.inspect_image(image=args.containerId)
+            inspect = d.inspect_image(image=args.imageId)
             cmd = inspect['Config']['Entrypoint']
             if not type(cmd) is list:
                 logging.error('ENTRYPOINT in Dockerfile must be a list in ' +
@@ -140,14 +140,14 @@ def command_grade_local(args):
                 raise
             cmd.extend(args.args)
             container = d.create_container(
-                image=args.containerId,
+                image=args.imageId,
                 entrypoint=cmd,
                 user=user,
                 host_config=host_config,
             )
         else:
             container = d.create_container(
-                image=args.containerId,
+                image=args.imageId,
                 user=user,
                 host_config=host_config,
             )

--- a/courseraprogramming/commands/inspect.py
+++ b/courseraprogramming/commands/inspect.py
@@ -49,7 +49,7 @@ def command_inspect(args):
         # Note: docker run CLI doesn't support setting the group. :-(
         command_line.append('-u')
         command_line.append('1000')
-    command_line.append(args.containerId)
+    command_line.append(args.imageId)
     logging.debug("About to execute command: %s", ' '.join(command_line))
     os.execvp('docker', command_line)
 

--- a/courseraprogramming/commands/ls.py
+++ b/courseraprogramming/commands/ls.py
@@ -31,7 +31,7 @@ def command_ls(args):
     d = utils.docker_client(args)
     try:
         container = d.create_container(
-            image=args.containerId,
+            image=args.imageId,
             entrypoint="/bin/ls",
             command=args.dir)
     except:

--- a/courseraprogramming/commands/upload.py
+++ b/courseraprogramming/commands/upload.py
@@ -50,9 +50,9 @@ def get_container_image(args, d):
     # TODO: get information on the image, and run a few basic sanity checks.
     # (e.g. check for ENTRYPOINT, etc.)
 
-    image = d.get_image(args.containerId)
+    image = d.get_image(args.imageId)
     image_file_name = \
-        args.containerId if args.file_name is None else args.file_name
+        args.imageId if args.file_name is None else args.file_name
     image_file_name = image_file_name.replace('/', '_')
     if not image_file_name.endswith('.tar'):
         image_file_name += '.tar'
@@ -61,7 +61,7 @@ def get_container_image(args, d):
     logging.debug('Image file path: %s', image_file_path)
     if not args.quiet > 0:
         sys.stdout.write(
-            'Saving image %s to %s...' % (args.containerId, image_file_path))
+            'Saving image %s to %s...' % (args.imageId, image_file_path))
         sys.stdout.flush()
     with open(image_file_path, 'w') as image_tar:
         image_tar.write(image.data)

--- a/tests/commands/cat_tests.py
+++ b/tests/commands/cat_tests.py
@@ -24,9 +24,9 @@ from mock import patch
 
 def test_cat_parsing():
     parser = main.build_parser()
-    args = parser.parse_args('cat containerId /root/foo bar /bar/baz'.split())
+    args = parser.parse_args('cat imageId /root/foo bar /bar/baz'.split())
     assert args.func == cat.command_cat
-    assert args.containerId == 'containerId'
+    assert args.imageId == 'imageId'
     assert args.file == ['/root/foo', 'bar', '/bar/baz']
 
 
@@ -44,7 +44,7 @@ def test_ls_run(utils):
 
     # Set up args
     args = argparse.Namespace()
-    args.containerId = 'testContainerId'
+    args.imageId = 'testImageId'
     args.file = '/grader/testCases.txt'
 
     with patch('courseraprogramming.commands.cat.sys.stdout') as stdout:
@@ -55,7 +55,7 @@ def test_ls_run(utils):
     stdout.write.assert_called_with(docker_mock.logs.return_value)
 
     docker_mock.create_container.assert_called_with(
-        image='testContainerId',
+        image='testImageId',
         entrypoint='/bin/cat',
         command='/grader/testCases.txt')
     docker_mock.start.assert_called_with(

--- a/tests/commands/grade_tests.py
+++ b/tests/commands/grade_tests.py
@@ -26,9 +26,9 @@ from testfixtures import LogCapture
 def test_grade_local_parsing():
     # TODO: mock out `os.path.isdir` to make this test more portable.
     parser = main.build_parser()
-    args = parser.parse_args('grade local myContainerId /tmp'.split())
+    args = parser.parse_args('grade local myimageId /tmp'.split())
     assert args.func == grade.command_grade_local
-    assert args.containerId == 'myContainerId'
+    assert args.imageId == 'myimageId'
     assert args.dir == '/tmp'
     assert not args.no_rm
 
@@ -36,9 +36,9 @@ def test_grade_local_parsing():
 def test_grade_local_parsing_with_extra_args():
     parser = main.build_parser()
     args = parser.parse_args(
-        'grade local --no-rm myContainerId /tmp arg1 arg2'.split())
+        'grade local --no-rm myimageId /tmp arg1 arg2'.split())
     assert args.func == grade.command_grade_local
-    assert args.containerId == 'myContainerId'
+    assert args.imageId == 'myimageId'
     assert args.dir == '/tmp'
     assert args.args == ['arg1', 'arg2']
     assert args.no_rm
@@ -49,7 +49,7 @@ def test_check_output_bad_isCorrect(sys):
     with LogCapture() as logs:
         docker_mock = MagicMock()
         container = {
-            "Id": "myContainerId"
+            "Id": "myimageId"
         }
         args = argparse.Namespace()
         args.timeout = 300
@@ -65,7 +65,7 @@ def test_check_output_bad_isCorrect(sys):
     logs.check(
         ('root', 'INFO', 'Debug log:'),
         ('root', 'ERROR', "Field 'isCorrect' is not a boolean value."),
-        ('root', 'DEBUG', "About to remove container: {'Id': 'myContainerId'}")
+        ('root', 'DEBUG', "About to remove container: {'Id': 'myimageId'}")
     )
     sys.exit.assert_called_with(1)
 
@@ -75,7 +75,7 @@ def test_check_output_no_feedback(sys):
     with LogCapture() as logs:
         docker_mock = MagicMock()
         container = {
-            "Id": "myContainerId"
+            "Id": "myimageId"
         }
         args = argparse.Namespace()
         args.timeout = 300
@@ -91,7 +91,7 @@ def test_check_output_no_feedback(sys):
     logs.check(
         ('root', 'INFO', 'Debug log:'),
         ('root', 'ERROR', "Field 'feedback' not present in parsed output."),
-        ('root', 'DEBUG', "About to remove container: {'Id': 'myContainerId'}")
+        ('root', 'DEBUG', "About to remove container: {'Id': 'myimageId'}")
     )
     sys.exit.assert_called_with(1)
 
@@ -101,7 +101,7 @@ def test_check_output_fractional_score_boolean(sys):
     with LogCapture() as logs:
         docker_mock = MagicMock()
         container = {
-            "Id": "myContainerId"
+            "Id": "myimageId"
         }
         args = argparse.Namespace()
         args.timeout = 300
@@ -117,7 +117,7 @@ def test_check_output_fractional_score_boolean(sys):
     logs.check(
         ('root', 'INFO', 'Debug log:'),
         ('root', 'ERROR', "Field 'fractionalScore' must be a decimal."),
-        ('root', 'DEBUG', "About to remove container: {'Id': 'myContainerId'}")
+        ('root', 'DEBUG', "About to remove container: {'Id': 'myimageId'}")
     )
     sys.exit.assert_called_with(1)
 
@@ -127,7 +127,7 @@ def test_check_output_fractional_score_string(sys):
     with LogCapture() as logs:
         docker_mock = MagicMock()
         container = {
-            "Id": "myContainerId"
+            "Id": "myimageId"
         }
         args = argparse.Namespace()
         args.timeout = 300
@@ -143,7 +143,7 @@ def test_check_output_fractional_score_string(sys):
     logs.check(
         ('root', 'INFO', 'Debug log:'),
         ('root', 'ERROR', "Field 'fractionalScore' must be a decimal."),
-        ('root', 'DEBUG', "About to remove container: {'Id': 'myContainerId'}")
+        ('root', 'DEBUG', "About to remove container: {'Id': 'myimageId'}")
     )
     sys.exit.assert_called_with(1)
 
@@ -153,7 +153,7 @@ def test_check_output_fractional_score_too_high(sys):
     with LogCapture() as logs:
         docker_mock = MagicMock()
         container = {
-            "Id": "myContainerId"
+            "Id": "myimageId"
         }
         args = argparse.Namespace()
         args.timeout = 300
@@ -169,7 +169,7 @@ def test_check_output_fractional_score_too_high(sys):
     logs.check(
         ('root', 'INFO', 'Debug log:'),
         ('root', 'ERROR', "Field 'fractionalScore' must be <= 1."),
-        ('root', 'DEBUG', "About to remove container: {'Id': 'myContainerId'}")
+        ('root', 'DEBUG', "About to remove container: {'Id': 'myimageId'}")
     )
     sys.exit.assert_called_with(1)
 
@@ -179,7 +179,7 @@ def test_check_output_fractional_score_too_low(sys):
     with LogCapture() as logs:
         docker_mock = MagicMock()
         container = {
-            "Id": "myContainerId"
+            "Id": "myimageId"
         }
         args = argparse.Namespace()
         args.timeout = 300
@@ -195,7 +195,7 @@ def test_check_output_fractional_score_too_low(sys):
     logs.check(
         ('root', 'INFO', 'Debug log:'),
         ('root', 'ERROR', "Field 'fractionalScore' must be >= 0."),
-        ('root', 'DEBUG', "About to remove container: {'Id': 'myContainerId'}")
+        ('root', 'DEBUG', "About to remove container: {'Id': 'myimageId'}")
     )
     sys.exit.assert_called_with(1)
 
@@ -205,7 +205,7 @@ def test_check_output_missing_grade(sys):
     with LogCapture() as logs:
         docker_mock = MagicMock()
         container = {
-            "Id": "myContainerId"
+            "Id": "myimageId"
         }
         args = argparse.Namespace()
         args.timeout = 300
@@ -221,7 +221,7 @@ def test_check_output_missing_grade(sys):
     logs.check(
         ('root', 'INFO', 'Debug log:'),
         ('root', 'ERROR', "Required field 'fractionalScore' is missing."),
-        ('root', 'DEBUG', "About to remove container: {'Id': 'myContainerId'}")
+        ('root', 'DEBUG', "About to remove container: {'Id': 'myimageId'}")
     )
     sys.exit.assert_called_with(1)
 
@@ -231,7 +231,7 @@ def test_check_output_malformed_output(sys):
     with LogCapture() as logs:
         docker_mock = MagicMock()
         container = {
-            "Id": "myContainerId"
+            "Id": "myimageId"
         }
         args = argparse.Namespace()
         args.timeout = 300
@@ -247,7 +247,7 @@ def test_check_output_malformed_output(sys):
     logs.check(
         ('root', 'INFO', 'Debug log:'),
         ('root', 'ERROR', "The output was not a valid JSON document."),
-        ('root', 'DEBUG', "About to remove container: {'Id': 'myContainerId'}")
+        ('root', 'DEBUG', "About to remove container: {'Id': 'myimageId'}")
     )
     sys.exit.assert_called_with(1)
 
@@ -257,7 +257,7 @@ def test_check_output_bad_return_code(sys):
     with LogCapture():
         docker_mock = MagicMock()
         container = {
-            "Id": "myContainerId"
+            "Id": "myimageId"
         }
         args = argparse.Namespace()
         args.timeout = 300
@@ -278,7 +278,7 @@ def test_check_output_good_output_is_correct(sys):
     with LogCapture() as logs:
         docker_mock = MagicMock()
         container = {
-            "Id": "myContainerId"
+            "Id": "myimageId"
         }
         args = argparse.Namespace()
         args.timeout = 300
@@ -293,7 +293,7 @@ def test_check_output_good_output_is_correct(sys):
         grade.run_container(docker_mock, container, args)
     logs.check(
         ('root', 'INFO', 'Debug log:'),
-        ('root', 'DEBUG', "About to remove container: {'Id': 'myContainerId'}")
+        ('root', 'DEBUG', "About to remove container: {'Id': 'myimageId'}")
     )
     assert not sys.exit.called, "sys.exit should not be called!"
 
@@ -303,7 +303,7 @@ def test_check_output_good_output_fractional_score(sys):
     with LogCapture() as logs:
         docker_mock = MagicMock()
         container = {
-            "Id": "myContainerId"
+            "Id": "myimageId"
         }
         args = argparse.Namespace()
         args.timeout = 300
@@ -318,7 +318,7 @@ def test_check_output_good_output_fractional_score(sys):
         grade.run_container(docker_mock, container, args)
     logs.check(
         ('root', 'INFO', 'Debug log:'),
-        ('root', 'DEBUG', "About to remove container: {'Id': 'myContainerId'}")
+        ('root', 'DEBUG', "About to remove container: {'Id': 'myimageId'}")
     )
     assert not sys.exit.called, "sys.exit should not be called!"
 
@@ -328,7 +328,7 @@ def test_check_output_good_output_fractional_score_one(sys):
     with LogCapture() as logs:
         docker_mock = MagicMock()
         container = {
-            "Id": "myContainerId"
+            "Id": "myimageId"
         }
         args = argparse.Namespace()
         args.timeout = 300
@@ -343,7 +343,7 @@ def test_check_output_good_output_fractional_score_one(sys):
         grade.run_container(docker_mock, container, args)
     logs.check(
         ('root', 'INFO', 'Debug log:'),
-        ('root', 'DEBUG', "About to remove container: {'Id': 'myContainerId'}")
+        ('root', 'DEBUG', "About to remove container: {'Id': 'myimageId'}")
     )
     assert not sys.exit.called, "sys.exit should not be called!"
 
@@ -353,7 +353,7 @@ def test_check_output_good_output_fractional_score_one_point_oh(sys):
     with LogCapture() as logs:
         docker_mock = MagicMock()
         container = {
-            "Id": "myContainerId"
+            "Id": "myimageId"
         }
         args = argparse.Namespace()
         args.timeout = 300
@@ -368,7 +368,7 @@ def test_check_output_good_output_fractional_score_one_point_oh(sys):
         grade.run_container(docker_mock, container, args)
     logs.check(
         ('root', 'INFO', 'Debug log:'),
-        ('root', 'DEBUG', "About to remove container: {'Id': 'myContainerId'}")
+        ('root', 'DEBUG', "About to remove container: {'Id': 'myimageId'}")
     )
     assert not sys.exit.called, "sys.exit should not be called!"
 
@@ -378,7 +378,7 @@ def test_check_output_good_output_fractional_score_zero(sys):
     with LogCapture() as logs:
         docker_mock = MagicMock()
         container = {
-            "Id": "myContainerId"
+            "Id": "myimageId"
         }
         args = argparse.Namespace()
         args.timeout = 300
@@ -393,7 +393,7 @@ def test_check_output_good_output_fractional_score_zero(sys):
         grade.run_container(docker_mock, container, args)
     logs.check(
         ('root', 'INFO', 'Debug log:'),
-        ('root', 'DEBUG', "About to remove container: {'Id': 'myContainerId'}")
+        ('root', 'DEBUG', "About to remove container: {'Id': 'myimageId'}")
     )
     assert not sys.exit.called, "sys.exit should not be called!"
 
@@ -403,7 +403,7 @@ def test_check_output_good_output_fractional_score_zero_point_oh(sys):
     with LogCapture() as logs:
         docker_mock = MagicMock()
         container = {
-            "Id": "myContainerId"
+            "Id": "myimageId"
         }
         args = argparse.Namespace()
         args.timeout = 300
@@ -418,7 +418,7 @@ def test_check_output_good_output_fractional_score_zero_point_oh(sys):
         grade.run_container(docker_mock, container, args)
     logs.check(
         ('root', 'INFO', 'Debug log:'),
-        ('root', 'DEBUG', "About to remove container: {'Id': 'myContainerId'}")
+        ('root', 'DEBUG', "About to remove container: {'Id': 'myimageId'}")
     )
     assert not sys.exit.called, "sys.exit should not be called!"
 
@@ -434,7 +434,7 @@ def test_command_local_grade_simple(
         common):
     args = argparse.Namespace()
     args.dir = '/tmp'
-    args.containerId = 'myContainerId'
+    args.imageId = 'myimageId'
 
     common.mk_submission_volume_str.return_value = 'foo'
     docker_mock = MagicMock()
@@ -455,7 +455,7 @@ def test_command_local_grade_simple(
         memswap_limit='1g',
     )
     docker_mock.create_container.assert_called_with(
-        image='myContainerId',
+        image='myimageId',
         user='1000',
         host_config=h_config,
     )
@@ -471,7 +471,7 @@ def test_command_local_grade_simple(
 def test_command_local_grade_with_extra_args(run_container, utils, common):
     args = argparse.Namespace()
     args.dir = '/tmp'
-    args.containerId = 'myContainerId'
+    args.imageId = 'myimageId'
     args.args = ['extra', 'args']
     common.mk_submission_volume_str.return_value = 'foo'
     docker_mock = MagicMock()
@@ -488,7 +488,7 @@ def test_command_local_grade_with_extra_args(run_container, utils, common):
     grade.command_grade_local(args)
 
     docker_mock.create_container.assert_called_with(
-        image='myContainerId',
+        image='myimageId',
         entrypoint=['command', 'extra', 'args'],
         user='1000',
         host_config=docker.utils.create_host_config(

--- a/tests/commands/inspect_tests.py
+++ b/tests/commands/inspect_tests.py
@@ -24,7 +24,7 @@ def test_inspect_parsing():
     parser = main.build_parser()
     args = parser.parse_args('inspect demo/primes'.split())
     assert args.func == inspect.command_inspect
-    assert args.containerId == 'demo/primes'
+    assert args.imageId == 'demo/primes'
     assert not args.no_rm
 
 
@@ -33,7 +33,7 @@ def test_ls_run(os):
 
     # Set up args
     args = argparse.Namespace()
-    args.containerId = 'testContainerId'
+    args.imageId = 'testImageId'
     args.shell = '/bin/bash'
     args.allow_network = False
     args.unlimited_memory = False
@@ -57,7 +57,7 @@ def test_ls_run(os):
         '--rm',
         '-u',
         '1000',
-        'testContainerId',
+        'testImageId',
     ])
 
 
@@ -66,7 +66,7 @@ def test_ls_run_without_limits(os):
 
     # Set up args
     args = argparse.Namespace()
-    args.containerId = 'testContainerId'
+    args.imageId = 'testImageId'
     args.shell = '/bin/bash'
     args.allow_network = True
     args.unlimited_memory = True
@@ -83,5 +83,5 @@ def test_ls_run_without_limits(os):
         '-it',
         '--entrypoint',
         '/bin/bash',
-        'testContainerId',
+        'testImageId',
     ])

--- a/tests/commands/ls_tests.py
+++ b/tests/commands/ls_tests.py
@@ -27,7 +27,7 @@ def test_ls_parsing_simple():
     args = parser.parse_args('ls a1b2c3 /'.split())
     assert args.func == ls.command_ls, "func: %s" % args.func
     assert args.dir == '/', "Dir is: %s" % args.dir
-    assert args.containerId == 'a1b2c3', "Container id: %s" % args.containerId
+    assert args.imageId == 'a1b2c3', "Container id: %s" % args.imageId
 
 
 def test_ls_parsing_flags():
@@ -35,7 +35,7 @@ def test_ls_parsing_flags():
     args = parser.parse_args('ls -al --human my-container /foo/bar'.split())
     assert args.func == ls.command_ls
     assert args.dir == '/foo/bar', args.dir
-    assert args.containerId == 'my-container', args.containerId
+    assert args.imageId == 'my-container', args.imageId
     assert args.a
     assert args.l
     assert args.human
@@ -55,7 +55,7 @@ def test_ls_run(utils):
 
     # Set up args
     args = argparse.Namespace()
-    args.containerId = 'testContainerId'
+    args.imageId = 'testImageId'
     args.dir = '/grader'
 
     with patch('courseraprogramming.commands.ls.sys.stdout') as stdout:
@@ -66,7 +66,7 @@ def test_ls_run(utils):
     stdout.write.assert_called_with(docker_mock.logs.return_value)
 
     docker_mock.create_container.assert_called_with(
-        image='testContainerId',
+        image='testImageId',
         entrypoint='/bin/ls',
         command='/grader')
     docker_mock.start.assert_called_with(

--- a/tests/commands/upload_tests.py
+++ b/tests/commands/upload_tests.py
@@ -27,8 +27,8 @@ from testfixtures import LogCapture
 def test_upload_parsing():
     parser = main.build_parser()
     args = parser.parse_args(
-               'upload CONTAINER_ID COURSE_ID ITEM_ID PART_ID'.split())
-    assert args.containerId == 'CONTAINER_ID'
+               'upload CONTAINER_IMAGE_ID COURSE_ID ITEM_ID PART_ID'.split())
+    assert args.imageId == 'CONTAINER_IMAGE_ID'
     assert args.course == 'COURSE_ID'
     assert args.item == 'ITEM_ID'
     assert args.part == 'PART_ID'
@@ -37,7 +37,8 @@ def test_upload_parsing():
 
 def test_upload_parsing_with_additional_items():
     parser = main.build_parser()
-    args = parser.parse_args('upload CONTAINER_ID COURSE_ID ITEM_ID PART_ID '
+    args = parser.parse_args('upload CONTAINER_IMAGE_ID COURSE_ID ITEM_ID '
+                             'PART_ID '
                              '--additional_item_and_part ITEM_2 PART_2 '
                              '--additional_item_and_part ITEM_3 PART_3'
                              .split())
@@ -47,7 +48,8 @@ def test_upload_parsing_with_additional_items():
 
 def test_upload_parsing_with_resource_customization():
     parser = main.build_parser()
-    args = parser.parse_args('upload CONTAINER_ID COURSE_ID ITEM_ID PART_ID '
+    args = parser.parse_args('upload CONTAINER_IMAGE_ID COURSE_ID ITEM_ID '
+                             'PART_ID '
                              '--grader-cpu 1 '
                              '--grader-memory-limit 1024 '
                              '--grading-timeout 300 '
@@ -61,7 +63,8 @@ def test_upload_parsing_with_resource_customization():
 def test_upload_parsing_invalid_cpu():
     parser = main.build_parser()
     try:
-        parser.parse_args('upload CONTAINER_ID COURSE_ID ITEM_ID PART_ID '
+        parser.parse_args('upload CONTAINER_IMAGE_ID COURSE_ID ITEM_ID '
+                          'PART_ID '
                           '--grader-cpu 3 '
                           '--grader-memory-limit 1024 '
                           '--grading-timeout 300 '
@@ -76,7 +79,8 @@ def test_upload_parsing_invalid_cpu():
 def test_upload_parsing_invalid_memory():
     parser = main.build_parser()
     try:
-        parser.parse_args('upload CONTAINER_ID COURSE_ID ITEM_ID PART_ID '
+        parser.parse_args('upload CONTAINER_IMAGE_ID COURSE_ID ITEM_ID '
+                          'PART_ID '
                           '--grader-cpu 1 '
                           '--grader-memory-limit 3 '
                           '--grading-timeout 300 '
@@ -91,7 +95,8 @@ def test_upload_parsing_invalid_memory():
 def test_upload_parsing_timeout_too_low():
     parser = main.build_parser()
     try:
-        parser.parse_args('upload CONTAINER_ID COURSE_ID ITEM_ID PART_ID '
+        parser.parse_args('upload CONTAINER_IMAGE_ID COURSE_ID ITEM_ID '
+                          'PART_ID '
                           '--grader-cpu 1 '
                           '--grader-memory-limit 1024 '
                           '--grading-timeout 299 '
@@ -106,7 +111,8 @@ def test_upload_parsing_timeout_too_low():
 def test_upload_parsing_timeout_too_high():
     parser = main.build_parser()
     try:
-        parser.parse_args('upload CONTAINER_ID COURSE_ID ITEM_ID PART_ID '
+        parser.parse_args('upload CONTAINER_IMAGE_ID COURSE_ID ITEM_ID '
+                          'PART_ID '
                           '--grader-cpu 1 '
                           '--grader-memory-limit 1024 '
                           '--grading-timeout 1801 '


### PR DESCRIPTION
Previously, we called the command line parameter that referred to the docker container image as "containerId". This is ambiguous, because it could also refer to a contaniner's id. Instead, it is more accurate to name this parameter as imageId. This commit makes that change, and also notes in the help documentation that it can refer to an image tag.
