### PR TITLE
Limit the docker-py versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(name='courseraprogramming',
       packages=['courseraprogramming', 'courseraprogramming.commands'],
       install_requires=[
           'dockerfile-parse>=0.0.3',
-          'docker-py>=1.2.3',
+          'docker-py>=1.2.3,<=1.6.0',
           'requests>=2.7.0',
           'semver>=2.2.0',
       ],


### PR DESCRIPTION
Coursera's production systems only support docker 1.9.1 and below. docker-py 1.8
only works with Docker 1.10, and docker-py. The 1.7.x series of docker-py has
problems on macs. So, instead, we limit docker-py to be 1.6.0 and below.
