### PR TITLE
Add memory limit options

### DIFF
--- a/courseraprogramming/commands/upload.py
+++ b/courseraprogramming/commands/upload.py
@@ -387,7 +387,7 @@ def setup_registration_parser(parser):
         type=int,
         choices=[1024, 2048, 3072, 4096],
         help='Amount of memory your grader is allocated when grading '
-             'submissions. You may choose from 1024, 2048, 3072 or ' 
+             'submissions. You may choose from 1024, 2048, 3072 or '
              '4096 MB. The default amount is 1024 MB.')
 
     parser.add_argument(

--- a/courseraprogramming/commands/upload.py
+++ b/courseraprogramming/commands/upload.py
@@ -387,7 +387,7 @@ def setup_registration_parser(parser):
         type=int,
         choices=[1024, 2048, 3072, 4096],
         help='Amount of memory your grader is allocated when grading '
-             'submissions. You may choose from 1024, 2048, 3072 or' 
+             'submissions. You may choose from 1024, 2048, 3072 or ' 
              '4096 MB. The default amount is 1024 MB.')
 
     parser.add_argument(

--- a/courseraprogramming/commands/upload.py
+++ b/courseraprogramming/commands/upload.py
@@ -387,8 +387,8 @@ def setup_registration_parser(parser):
         type=int,
         choices=[1024, 2048, 3072, 4096],
         help='Amount of memory your grader is allocated when grading '
-             'submissions. You may choose from 1024, 2048, 3072 or 4096 MB. The '
-             'default amount is 1024 MB.')
+             'submissions. You may choose from 1024, 2048, 3072 or 
+             '4096 MB. The default amount is 1024 MB.')
 
     parser.add_argument(
         '--grading-timeout',

--- a/courseraprogramming/commands/upload.py
+++ b/courseraprogramming/commands/upload.py
@@ -387,7 +387,7 @@ def setup_registration_parser(parser):
         type=int,
         choices=[1024, 2048, 3072, 4096],
         help='Amount of memory your grader is allocated when grading '
-             'submissions. You may choose from 1024, 2048, 3072 or 
+             'submissions. You may choose from 1024, 2048, 3072 or' 
              '4096 MB. The default amount is 1024 MB.')
 
     parser.add_argument(

--- a/courseraprogramming/commands/upload.py
+++ b/courseraprogramming/commands/upload.py
@@ -385,9 +385,9 @@ def setup_registration_parser(parser):
     parser.add_argument(
         '--grader-memory-limit',
         type=int,
-        choices=[1024, 2048],
+        choices=[1024, 2048, 3072, 4096],
         help='Amount of memory your grader is allocated when grading '
-             'submissions. You may choose from 1024 MB or 2048 MB. The '
+             'submissions. You may choose from 1024, 2048, 3072 or 4096 MB. The '
              'default amount is 1024 MB.')
 
     parser.add_argument(


### PR DESCRIPTION
Allow 3 and 4GB memory limit for uploaded executors