### PR TITLE
Allow broader set of URLs

### DIFF
--- a/courseraprogramming/commands/upload.py
+++ b/courseraprogramming/commands/upload.py
@@ -167,7 +167,7 @@ def poll_transloadit(args, upload_url):
                     body)
                 raise Exception('Error parsing the transloadit response.')
             else:
-                match = re.match('https://([^\\.]+).s3.amazonaws.com/(.+)',
+                match = re.match('https://([^\\.]+).s3[^\\.]*.amazonaws.com/(.+)',
                                  s3_link)
                 if match is None:
                     logging.error(

--- a/courseraprogramming/commands/upload.py
+++ b/courseraprogramming/commands/upload.py
@@ -167,8 +167,10 @@ def poll_transloadit(args, upload_url):
                     body)
                 raise Exception('Error parsing the transloadit response.')
             else:
-                match = re.match('https://([^\\.]+).s3[^\\.]*.amazonaws.com/(.+)',
-                                 s3_link)
+                match = re.match(
+                    'https://([^\\.]+).s3[^\\.]*.amazonaws.com/(.+)',
+                    s3_link
+                )
                 if match is None:
                     logging.error(
                         'Could not parse the uploaded url correctly. URL: %s',


### PR DESCRIPTION
Last time I uploaded a grader to Coursera I got an error `Error parsing the upload url!`. After some investigation I found out that the URL was `https://coursera-uploads.s3-eu-west-1.amazonaws.com/...`. 

See, now it is `s3-eu-west-1.amazonaws`, not just `s3.amazonaws`. So I changed the regexp accordingly.