### PR TITLE
Fix uploads from Europe

### DIFF
--- a/courseraprogramming/commands/upload.py
+++ b/courseraprogramming/commands/upload.py
@@ -167,7 +167,7 @@ def poll_transloadit(args, upload_url):
                     body)
                 raise Exception('Error parsing the transloadit response.')
             else:
-                match = re.match('https://([^\\.]+).s3.amazonaws.com/(.+)',
+                match = re.match('https://([^\\.]+).s3[^.]*.amazonaws.com/(.+)',
                                  s3_link)
                 if match is None:
                     logging.error(


### PR DESCRIPTION
Was receiving error message:

Error: root:Could not parse the uploaded url correctly: URL:
https.//coursera-uploads.s3-e1-west-1.amazonaws.com/...

Problem was that upload was checking for s3.amazonaws.com as part of its
regular expression, and so not matching s3-e1-west-1.amzonaws.com.