### PR TITLE
Imitate the real docker environment on Coursera

### DIFF
--- a/courseraprogramming/commands/grade.py
+++ b/courseraprogramming/commands/grade.py
@@ -138,11 +138,17 @@ def command_grade_local(args):
     try:
         volume_str = common.mk_submission_volume_str(args.dir)
         logging.debug("Volume string: %s", volume_str)
+
+        extra_hosts = {
+            'somehost': "192.168.1.2",
+        }
+
         host_config = d.create_host_config(
                 binds=[volume_str, ],
                 network_mode='none',
                 mem_limit=memory_limit,
                 memswap_limit=memory_limit,
+                extra_hosts=extra_hosts,
             )
         user = '%s' % 1000
 
@@ -161,6 +167,7 @@ def command_grade_local(args):
                 entrypoint=cmd,
                 user=user,
                 host_config=host_config,
+                hostname='somehost',
             )
         else:
             container = d.create_container(


### PR DESCRIPTION
I'm a TA for UIUC CS498 Cloud Computing Applications.

When we were developing the auto-grader for this course, we have a difficulty to debug using `courseraprogramming` locally because it only disables the network when running our images without setting the hostname to `somehost` and adding the `somehost:192.168.1.2` to `/etc/hosts` file. The `courseraprogramming`'s behavior is inconsistent with the real Coursera backend behavior.

To debug efficiently, I modify the `courseraprogramming` to let it imitate the way our images are running on your platform.

I don't have time to make the code nice and clean. I just hard code everything there. But I think it's clear enough to let you guys know what we want in `courseraprogramming`.

Hopefully, you can kindly update this tool for the users of Coursera could have a better experience when developing auto-grader.